### PR TITLE
fix: comment out Java 17 path for CI compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,5 +20,6 @@ android.useAndroidX=true
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 
-# Set Java 17 for Gradle
-org.gradle.java.home=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home
+# Set Java 17 for Gradle - commented out to fix GitHub Actions build
+# This path is specific to local macOS environment and won't work on CI runners
+# org.gradle.java.home=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home


### PR DESCRIPTION
Comment out the Java 17 path in gradle.properties to ensure 
compatibility with GitHub Actions build environment. The 
previous path is specific to a local macOS setup and causes 
build failures on CI runners.